### PR TITLE
feat(cache): add Redis `@Cacheable` for seat map endpoint

### DIFF
--- a/src/main/java/com/treserve/booking/BookingController.java
+++ b/src/main/java/com/treserve/booking/BookingController.java
@@ -19,23 +19,14 @@ import java.util.stream.Collectors;
 @Tag(name = "Booking", description = "Ядро — бронирование мест")
 public class BookingController {
 
-    private final TicketRepository ticketRepository;
+    private final SeatService seatService;
     private final BookingService bookingService;
 
     @GetMapping("/api/events/{eventId}/seats")
     @Tag(name = "Events")
-    @Operation(summary = "Карта мест: все места + их статусы (polling каждые 3 сек)")
+    @Operation(summary = "Карта мест: все места + их статусы (polling каждые 3 сек, Redis cached)")
     public List<SeatInfo> getSeats(@PathVariable Long eventId) {
-        return ticketRepository.findByEventIdWithSeat(eventId).stream()
-            .map(t -> new SeatInfo(
-                t.getSeat().getId(),
-                t.getSeat().getSeatLabel(),
-                t.getSeat().getRowLabel(),
-                t.getSeat().getSeatNumber(),
-                t.getStatus().name(),
-                t.getPrice()
-            ))
-            .collect(Collectors.toList());
+        return seatService.getSeats(eventId);
     }
 
     @PostMapping("/api/bookings/lock")

--- a/src/main/java/com/treserve/booking/BookingService.java
+++ b/src/main/java/com/treserve/booking/BookingService.java
@@ -22,6 +22,7 @@ public class BookingService {
 
     private final TicketRepository ticketRepository;
     private final UserRepository userRepository;
+    private final SeatService seatService;
 
     @Value("${app.booking.lock-duration-minutes:10}")
     private int lockDurationMinutes;
@@ -63,6 +64,7 @@ public class BookingService {
             log.info("LOCKED seat {} for event {} by user {} (expires {})",
                 seatId, eventId, userId, expiresAt);
 
+            seatService.evictSeatsCache(eventId);
             return new LockResponse(ticket.getId(), expiresAt);
 
         } catch (PessimisticLockingFailureException e) {
@@ -100,6 +102,7 @@ public class BookingService {
 
         ticketRepository.save(ticket);
 
+        seatService.evictSeatsCache(ticket.getEvent().getId());
         log.info("BOOKED ticket {} for user {}", ticketId, userId);
     }
 
@@ -126,6 +129,7 @@ public class BookingService {
 
         ticketRepository.save(ticket);
 
+        seatService.evictSeatsCache(ticket.getEvent().getId());
         log.info("CANCELLED lock on ticket {} by user {}", ticketId, userId);
     }
 }

--- a/src/main/java/com/treserve/booking/SafetyNetScheduler.java
+++ b/src/main/java/com/treserve/booking/SafetyNetScheduler.java
@@ -25,6 +25,7 @@ import java.util.List;
 public class SafetyNetScheduler {
 
     private final TicketRepository ticketRepository;
+    private final SeatService seatService;
 
     @Scheduled(fixedRate = 30_000) // каждые 30 секунд
     @Transactional
@@ -42,6 +43,12 @@ public class SafetyNetScheduler {
         }
 
         ticketRepository.saveAll(expired);
+
+        // Инвалидировать кэш для каждого затронутого ивента
+        expired.stream()
+            .map(t -> t.getEvent().getId())
+            .distinct()
+            .forEach(seatService::evictSeatsCache);
 
         log.info("SafetyNet: released {} expired locks", expired.size());
     }

--- a/src/main/java/com/treserve/booking/SeatService.java
+++ b/src/main/java/com/treserve/booking/SeatService.java
@@ -1,0 +1,59 @@
+package com.treserve.booking;
+
+import com.treserve.booking.dto.SeatInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Сервис карты мест с Redis кэшем.
+ *
+ * GET /api/events/{id}/seats вызывается polling'ом каждые 3 сек.
+ * При 100 юзерах на одном ивенте = ~33 RPS на один endpoint.
+ * Redis кэш (TTL 10 сек) снижает нагрузку на PG в ~3 раза.
+ *
+ * Cache invalidation: evictSeatsCache() вызывается при lock/confirm/cancel.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SeatService {
+
+    private final TicketRepository ticketRepository;
+
+    /**
+     * Получить карту мест для ивента.
+     * Кэшируется в Redis с TTL 10 сек (настроено в RedisCacheConfig).
+     *
+     * Первый запрос → PG query → Redis SET → ответ.
+     * Следующие запросы (в течение 10 сек) → Redis GET → ответ (без PG).
+     */
+    @Cacheable(value = "seats", key = "#eventId")
+    public List<SeatInfo> getSeats(Long eventId) {
+        log.debug("Cache MISS for seats:{} — querying PG", eventId);
+        return ticketRepository.findByEventIdWithSeat(eventId).stream()
+            .map(t -> new SeatInfo(
+                t.getSeat().getId(),
+                t.getSeat().getSeatLabel(),
+                t.getSeat().getRowLabel(),
+                t.getSeat().getSeatNumber(),
+                t.getStatus().name(),
+                t.getPrice()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Инвалидировать кэш карты мест.
+     * Вызывается после любого изменения статуса билета (lock/confirm/cancel/safety-net).
+     */
+    @CacheEvict(value = "seats", key = "#eventId")
+    public void evictSeatsCache(Long eventId) {
+        log.debug("Cache EVICT for seats:{}", eventId);
+    }
+}

--- a/src/main/java/com/treserve/booking/dto/SeatInfo.java
+++ b/src/main/java/com/treserve/booking/dto/SeatInfo.java
@@ -2,11 +2,13 @@ package com.treserve.booking.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class SeatInfo {
     private Long seatId;
     private String seatLabel;    // "A-12"

--- a/src/main/java/com/treserve/config/RedisCacheConfig.java
+++ b/src/main/java/com/treserve/config/RedisCacheConfig.java
@@ -1,0 +1,59 @@
+package com.treserve.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    /**
+     * Кэш-менеджер с разными TTL для разных кэшей.
+     *
+     * seats:{eventId} — TTL 10 сек (polling каждые 3 сек, кэш покрывает 3+ запроса)
+     * events — TTL 60 сек (список ивентов меняется редко)
+     */
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // Jackson ObjectMapper без type-metadata
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+            objectMapper.getPolymorphicTypeValidator(),
+            ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        var jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // Default: 30 сек TTL
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(30))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
+            .disableCachingNullValues();
+
+        // Per-cache TTL
+        Map<String, RedisCacheConfiguration> cacheConfigs = Map.of(
+            "seats", defaultConfig.entryTtl(Duration.ofSeconds(10)),  // seats — 10 сек
+            "events", defaultConfig.entryTtl(Duration.ofSeconds(60))  // events — 60 сек
+        );
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigs)
+            .build();
+    }
+}

--- a/src/main/java/com/treserve/config/SecurityConfig.java
+++ b/src/main/java/com/treserve/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000")); // Angular: "http://localhost:4200"
+        config.setAllowedOrigins(List.of("http://localhost:4200", "http://localhost:5173", "http://localhost:3000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
- Add RedisCacheConfig with TTL: seats=10s, events=60s
- Add SeatService with @Cacheable + @CacheEvict
- BookingController uses SeatService instead of TicketRepository directly
- BookingService invalidates seats cache after lock/confirm/cancel
- SafetyNetScheduler invalidates cache per event after auto-cancel
- SeatInfo: add @NoArgsConstructor for Jackson deserialization from Redis
- SecurityConfig: add Angular port 4200