### PR TITLE
fix(security): restrict actuator, JWT TTL 15min, CORS env var, no stacktrace

### DIFF
--- a/treserve-app/src/main/java/com/treserve/config/SecurityConfig.java
+++ b/treserve-app/src/main/java/com/treserve/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -34,6 +35,10 @@ public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
     private final ObjectMapper objectMapper;
+
+    // Разрешенные CORS origins. Для продакшена (например, на Railway) переопределяется через переменную окружения CORS_ALLOWED_ORIGINS
+    @Value("${cors.allowed-origins:http://localhost:4200,http://localhost:5173,http://localhost:3000,http://localhost}")
+    private String corsAllowedOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -62,8 +67,9 @@ public class SecurityConfig {
                     "/api-docs", "/api-docs/**"
                 ).permitAll()
 
-                // Actuator + Error + Instance info (LB demo)
-                .requestMatchers("/actuator/**", "/error", "/api/instance").permitAll()
+                // Actuator — только health (healthcheck) и prometheus (scraping) публичны
+                .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/prometheus", "/error", "/api/instance").permitAll()
+                .requestMatchers("/actuator/**").hasRole("ADMIN")
 
                 // Admin
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
@@ -83,7 +89,9 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:4200", "http://localhost:5173", "http://localhost:3000", "http://localhost"));
+        // Читаем из env var — Railway задаёт CORS_ALLOWED_ORIGINS для прода
+        List<String> origins = List.of(corsAllowedOrigins.split(","));
+        config.setAllowedOrigins(origins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/treserve-app/src/main/resources/application.yml
+++ b/treserve-app/src/main/resources/application.yml
@@ -55,7 +55,7 @@ spring:
 app:
   jwt:
     secret: ${JWT_SECRET:t-reserve-super-secret-key-change-in-prod-256-bits-minimum}
-    expiration-ms: 86400000       # 24 hours (access token)
+    expiration-ms: 900000          # 15 min (access token) — ранее 24h, уменьшено для безопасности
     refresh-expiration-ms: 604800000  # 7 days (refresh token)
   booking:
     lock-duration-minutes: 10
@@ -89,11 +89,17 @@ logging:
     com.treserve: DEBUG
     org.springframework.security: DEBUG
 
-# ═══ Error details ═══
+# ═══ CORS ═══
+# Разрешенные CORS origins. Для продакшена (например, на Railway) переопределяется через переменную окружения CORS_ALLOWED_ORIGINS
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:5173,http://localhost:3000,http://localhost}
+
+# ═══ Server ═══
 server:
+  port: ${PORT:8080}   # Railway задаёт PORT автоматически; локально — 8080
   error:
     include-message: always
-    include-stacktrace: on_param
+    include-stacktrace: never    # never в проде — не светим стектрейсы
 
 # ═══ MinIO (S3-compatible storage) ═══
 minio:


### PR DESCRIPTION
## Что фиксится

Closes #55, #56 (частично)

### Изменения

#### SecurityConfig.java
- Actuator: только /actuator/health и /actuator/prometheus публичны. Остальные (/actuator/metrics, /actuator/info и т.д.) требуют роли ADMIN
- CORS: allowed origins теперь конфигурируются через CORS_ALLOWED_ORIGINS env var. Дефолт — localhost адреса для локальной разработки

#### Application.yml
- **JWT TTL**: access token 24h → **15 минут** (стандарт)
- **Stack trace**: on_param → ever — стектрейсы больше не утекают в ответах
- Добавлена секция cors.allowed-origins для Railway деплоя

### Как задать CORS для Railway
```
CORS_ALLOWED_ORIGINS=https://frontend-xxx.up.railway.app,https://treserve-app-xxx.up.railway.app
```

### Проверка
- GET /actuator/info без токена → 403
- GET /actuator/health без токена → 200
- GET /actuator/prometheus без токена → 200 (нужен для Prometheus scraping)