### PR TITLE
fix(frontend): use proxy_host for websocket Host header

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,7 +28,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
 
         proxy_read_timeout 86400;
         proxy_send_timeout 86400;


### PR DESCRIPTION
Fixes Railway internal routing rejecting WebSocket connections due to wrong Host header.