### PR TITLE
fix: pure websockets and prevent double payment

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,6 +29,10 @@ server {
         proxy_set_header Connection "Upgrade";
 
         proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
 
         proxy_read_timeout 86400;
         proxy_send_timeout 86400;

--- a/frontend/src/app/pages/payment/payment.component.ts
+++ b/frontend/src/app/pages/payment/payment.component.ts
@@ -118,14 +118,19 @@ export class PaymentComponent implements OnInit, OnDestroy {
   }
 
   payFree(): void {
-    if (!this.lockId) return;
+    if (!this.lockId || this.isLoading) return;
+    
+    this.isLoading = true;
+    this.errorMessage = null;
 
     this.bookingService.confirmBooking(this.lockId).subscribe({
       next: () => {
+        this.isLoading = false;
         sessionStorage.removeItem(this.LOCK_KEY);
         this.router.navigate(['/payment-success']);
       },
       error: () => {
+        this.isLoading = false;
         this.errorMessage = 'Ошибка оплаты';
       },
     });


### PR DESCRIPTION
Adds missing X-Forwarded headers to Nginx to allow Spring Boot to accept wss:// upgrades, and disables the payment button while loading to prevent 409 Conflict.