### PR TITLE
fix: resolve OAuth2 authorization_request_not_found on Railway

### DIFF
--- a/treserve-app/src/main/java/com/treserve/common/utils/CookieUtils.java
+++ b/treserve-app/src/main/java/com/treserve/common/utils/CookieUtils.java
@@ -1,6 +1,6 @@
 package com.treserve.common.utils;
 
-import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie; // still needed for getCookie() and deserialize()
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.util.SerializationUtils;
@@ -25,33 +25,54 @@ public class CookieUtils {
     /**
      * Добавляет cookie в ответ.
      *
-     * @param secure должен совпадать с request.isSecure() — true для HTTPS (прод),
-     *               false для HTTP (локальная разработка)
+     * Пишем Set-Cookie заголовок напрямую, а не через Cookie API.
+     * Причина: Tomcat/Servlet Cookie API не гарантирует корректную сериализацию
+     * SameSite=None в паре с Secure через cookie.setAttribute() во всех версиях.
+     * Chrome ОТБРАСЫВАЕТ SameSite=None куки без Secure=true — это первопричина
+     * authorization_request_not_found в Railway деплоях.
+     *
+     * @param secure true для HTTPS (прод/Railway), false для HTTP (локально)
      */
     public static void addCookie(HttpServletResponse response, String name, String value,
             int maxAge, boolean secure) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(secure); // HTTPS → true, localhost HTTP → false
-        cookie.setMaxAge(maxAge);
-        cookie.setAttribute("SameSite", secure ? "None" : "Lax"); // Important for cross-site Railway cookies
-        response.addCookie(cookie);
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=").append(value);
+        sb.append("; Path=/");
+        sb.append("; HttpOnly");
+        sb.append("; Max-Age=").append(maxAge);
+        if (secure) {
+            sb.append("; Secure");
+            sb.append("; SameSite=None"); // Требуется для cross-site OAuth2 callback (Google → backend)
+        } else {
+            sb.append("; SameSite=Lax");  // Локально HTTP — Lax достаточно
+        }
+        response.addHeader("Set-Cookie", sb.toString());
     }
 
+    /**
+     * Удаляет cookie установкой Max-Age=0.
+     * Также пишем напрямую в заголовок — по той же причине что и addCookie.
+     */
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
         Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals(name)) {
-                    cookie.setValue("");
-                    cookie.setPath("/");
-                    cookie.setMaxAge(0);
-                    boolean isSecure = request.isSecure() || "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Proto"));
-                    cookie.setSecure(isSecure);
-                    cookie.setAttribute("SameSite", isSecure ? "None" : "Lax");
-                    response.addCookie(cookie);
+        if (cookies == null) return;
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) {
+                // native strategy: request.isSecure() уже true на Railway (Tomcat RemoteIpValve)
+                boolean isSecure = request.isSecure()
+                        || "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Proto"));
+                StringBuilder sb = new StringBuilder();
+                sb.append(name).append("=");
+                sb.append("; Path=/");
+                sb.append("; HttpOnly");
+                sb.append("; Max-Age=0");
+                if (isSecure) {
+                    sb.append("; Secure");
+                    sb.append("; SameSite=None");
+                } else {
+                    sb.append("; SameSite=Lax");
                 }
+                response.addHeader("Set-Cookie", sb.toString());
             }
         }
     }

--- a/treserve-app/src/main/resources/application.yml
+++ b/treserve-app/src/main/resources/application.yml
@@ -149,7 +149,7 @@ cors:
 # ═══ Server ═══
 server:
   port: ${PORT:8080}   # Railway задаёт PORT автоматически; локально — 8080
-  forward-headers-strategy: framework
+  forward-headers-strategy: native
   tomcat:
     remoteip:
       internal-proxies: .*


### PR DESCRIPTION
Root cause: Two issues combined caused Chrome to silently drop the oauth2_auth_request cookie:

1. forward-headers-strategy=framework + remoteip.internal-proxies=.* caused DOUBLE header processing (Tomcat valve + Spring filter), leading to inconsistent request.isSecure() in some code paths. Fixed: changed to native strategy (Tomcat valve only, no conflict).

2. Tomcat Cookie API does not reliably serialize SameSite=None;Secure via cookie.setAttribute() in all Tomcat versions. Chrome rejects SameSite=None cookies without Secure=true and drops them silently. Fixed: write Set-Cookie header directly as raw string in CookieUtils (addCookie + deleteCookie) to guarantee correct attributes.