### PR TITLE
fix: nginx exact match for /oauth2/callback serves Angular SPA

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,6 +20,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    # Angular OAuth2 callback page — exact match перехватывает ДО блока /oauth2/ proxy
+    # Бэкенд редиректит сюда: /oauth2/callback#token=...&refreshToken=...
+    # Angular читает токены из fragment (#) и сохраняет в localStorage
+    location = /oauth2/callback {
+        try_files $uri /index.html;
+    }
+
     # Proxy OAuth2 initiation
     location /oauth2/ {
         proxy_pass ${BACKEND_URL}/oauth2/;


### PR DESCRIPTION
Backend redirects to frontend /oauth2/callback#token=... Nginx location /oauth2/ block was proxying it to backend (404). Added location = /oauth2/callback before the proxy block. Nginx processes exact matches first, serving index.html for Angular.